### PR TITLE
Dev depend on typescript

### DIFF
--- a/.changeset/smart-carrots-rescue.md
+++ b/.changeset/smart-carrots-rescue.md
@@ -1,0 +1,5 @@
+---
+"@inngest/workflow-kit": patch
+---
+
+Include TypeScript in dev dependencies

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -92,6 +92,7 @@
     "preset": "link:@storybook/react-vite/preset",
     "prop-types": "^15.8.1",
     "storybook": "^8.2.9",
-    "ts-jest": "^29.1.5"
+    "ts-jest": "^29.1.5",
+    "typescript": "^5.6.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       ts-jest:
         specifier: ^29.1.5
         version: 29.2.5(@babel/core@7.25.2)(@jest/transform@29.7.0)(@jest/types@29.6.3)(babel-jest@29.7.0(@babel/core@7.25.2))(esbuild@0.23.1)(jest@29.7.0(@types/node@22.5.5))(typescript@5.6.2)
+      typescript:
+        specifier: 5.6.2
+        version: 5.6.2
 
 packages:
 


### PR DESCRIPTION
While trying to build this project locally, I ran into the following failure:

<img width="932" alt="Screenshot 2024-12-04 at 5 26 56 PM" src="https://github.com/user-attachments/assets/93fca65b-0508-45ce-90fb-674d49091cb0">

Note the `tsc: command not found`

I don't have TypeScript installed globally because it's common to have projects with different version requirements. I thought you might have left the dependency out on purpose due to different preferred practices, but I thought I'd put this up as a conversation starter.

If nothing else, putting the dependency here makes sure that developers and build systems stay in sync about which version to use.