### PR TITLE
Fix toggling between nodes with inputs

### DIFF
--- a/packages/workflow/src/ui/sidebar/Sidebar.tsx
+++ b/packages/workflow/src/ui/sidebar/Sidebar.tsx
@@ -67,7 +67,9 @@ const useSidebarContent = () => {
       return (
         <>
           <SidebarHeader />
-          <SidebarActionForm workflowAction={workflowAction} engineAction={engineAction} />
+          {/* Include a key attribute so that the inputs in the action
+          update as the selected node changes. */}
+          <SidebarActionForm workflowAction={workflowAction} engineAction={engineAction} key={`node-${selectedNode.id}`} />
           <SidebarFooter />
         </>
       )


### PR DESCRIPTION
Before this fix, toggling between two nodes of the same time in the UI did not update the input values. Using the `key` attribute forces the UI to properly update the action form.