### PR TITLE
Small conditional support fixes

### DIFF
--- a/.changeset/healthy-shoes-hear.md
+++ b/.changeset/healthy-shoes-hear.md
@@ -1,0 +1,5 @@
+---
+"@inngest/workflow-kit": patch
+---
+
+Minor improvements to conditional support

--- a/packages/workflow/src/builtin.ts
+++ b/packages/workflow/src/builtin.ts
@@ -47,8 +47,8 @@ export const builtinActions: Record<string, EngineAction> = {
     edges: {
       allowAdd: false,
       edges: [
-        { name: "True", conditional: { type: "if", ref: "!ref($.result)" } },
-        { name: "False", conditional: { type: "else", ref: "!ref($.result)" } },
+        { name: "True", conditional: { type: "if", ref: "!ref($.output.result)" } },
+        { name: "False", conditional: { type: "else", ref: "!ref($.output.result)" } },
       ]
     },
   }

--- a/packages/workflow/src/interpolation.ts
+++ b/packages/workflow/src/interpolation.ts
@@ -59,8 +59,6 @@ export function refs(input: any): Array<{ path: string, ref: string }> {
 export function interpolate(value: any, vars: Record<string, any>) {
   let result = value;
 
-  // TODO: Handle $.result
-
   if (isRef(result)) {
     // Handle pure references immediately.  Remove "!ref(" and ")"
     result = result.replace("!ref(", "")


### PR DESCRIPTION
This is a pretty minor improvement, but the use of `$.result` was confusing when building my own conditinoal workflow. I don't believe the comment is needed anymore either. Using `$.output.result` works fine