### PR TITLE
Show edge names in editor

### DIFF
--- a/.changeset/orange-coins-speak.md
+++ b/.changeset/orange-coins-speak.md
@@ -1,0 +1,5 @@
+---
+"@inngest/workflow-kit": minor
+---
+
+Show edge names in editor

--- a/packages/workflow/src/ui/layout.tsx
+++ b/packages/workflow/src/ui/layout.tsx
@@ -162,6 +162,7 @@ export const parseWorkflow = ({ workflow, trigger, blankNodeParent }: parseWorkf
       id: `${edge.from}-${edge.to}`,
       source: edge.from,
       target: edge.to,
+      label: edge.name,
       type: 'smoothstep',
     });
   });


### PR DESCRIPTION
With this small change, the `True` and `False` labels will be shown on edges of conditional blocks