### PR TITLE
Export WorkflowEdge from library

### DIFF
--- a/packages/workflow/src/index.ts
+++ b/packages/workflow/src/index.ts
@@ -4,6 +4,7 @@ export {
   type EngineAction,
   type PublicEngineAction,
   type WorkflowAction,
+  type WorkflowEdge,
   type Loader,
   type Workflow,
 } from "./types";


### PR DESCRIPTION
Exports the WorkflowEdge type from the library so it can be implemented/used by library users.